### PR TITLE
Spiral pierce immune fix

### DIFF
--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -1668,7 +1668,7 @@ int skill_additional_effect(struct block_list* src, struct block_list *bl, uint1
 
 	case LK_SPIRALPIERCE:
 	case ML_SPIRALPIERCE:
-		if( dstsd || ( dstmd && status_bl_has_mode(bl,MD_STATUSIMMUNE) ) ) //Does not work on status immune
+		if( dstsd || ( dstmd && !status_bl_has_mode(bl,MD_STATUSIMMUNE) ) ) //Does not work on status immune
 			sc_start(src,bl,SC_STOP,100,0,skill_get_time2(skill_id,skill_lv));
 		break;
 


### PR DESCRIPTION
Fixes the inversion of target type being stopped by spiral pierce, ie it should stop normal monsters and not status immune

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->
https://github.com/rathena/rathena/issues/6667
* **Server Mode**: 

Both

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
Now applies root when target is not immune